### PR TITLE
add a little noise on differential.evolution proposal

### DIFF
--- a/R/d.e.mcmc.R
+++ b/R/d.e.mcmc.R
@@ -46,9 +46,10 @@ d.e.mcmc <- function(f, inits, max.iter, n.walkers, ...) {
   p()
 
   for (l in seq_len(chain.length)[-1]) {
-    z <- 2.38 / sqrt(2 * n.params)
+    ## # See Nelson et al. (2013), eq(10): https://doi.org/10.1088/0067-0049/210/1/11/.
+    gamma0 <- 2.38 / sqrt(2 * n.params) 
     if (l %% 10 == 0) {
-      z <- 1
+      gamma0 <- 1
     }
 
     ## random split into two subsets
@@ -73,6 +74,8 @@ d.e.mcmc <- function(f, inits, max.iter, n.walkers, ...) {
       active <- ensemble[active.idx, , drop = FALSE]
 
       ## proposal  x' = x + z · (y₁ − y₂)
+      ## See Nelson et al. (2013), eq(10), values are based on the defaults of Emcee.
+      z <- gamma0 * rnorm(length(active.idx), 1, 1e-5)
       prop <- active + z * (partner.1 - partner.2)
 
       ## acceptance probability


### PR DESCRIPTION
This is a tiny fix for a mostly theoretical problem. With differential evolution there is not guarantee that we can reach every point in space; we may walk on a grid. 

For this reason Ter Braak (2006) adds a small multivariate Gaussian noise, but as pointed out in the [emcee code](https://github.com/dfm/emcee/blob/c75406b1a6bf197f71f9e56068e9ea57af08be54/src/emcee/moves/de.py#L54C1-L61C1) making the factor `z` stochastic as proposed by [Nelson et al. 2013](https://doi.org/10.1088/0067-0049/210/1/11/) is nicer as it keeps the idea of affine-invariance.

I'm using a very small value for the noise that corresponds to the default of that emcee. As I said, this does not fix a practical problem, but it helps to keeps the mathematicians happy :)
